### PR TITLE
Change to Object.prototype.hasOwnProperty.call due to changes in node.js. Also check for null.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ module.exports = function(schema) {
           let keyIsArray = Array.isArray(updateData[attribute]);
           let isObjectWithKeys = typeof modelInstance[attribute] == 'object' && !keyIsArray && Object.keys(modelInstance[attribute]).length;
 
-          let keyIsUpdatable = updateData.hasOwnProperty(attribute) && attribute !== '_id' && !isProtectedKey && !isObjectWithKeys;
-          let isNestedKey = updateData.hasOwnProperty(attribute) && attribute !== '_id' && !isProtectedKey && isObjectWithKeys;
+          let keyIsUpdatable = Object.prototype.hasOwnProperty.call(updateData, attribute) && attribute !== '_id' && !isProtectedKey && !isObjectWithKeys;
+          let isNestedKey = Object.prototype.hasOwnProperty.call(updateData, attribute) && attribute !== '_id' && !isProtectedKey && isObjectWithKeys;
 
           if (keyIsUpdatable)
             modelInstance[attribute] = updateData[attribute];

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(schema) {
         for (var attribute in updateData) {
           let isProtectedKey = protectedKeys.indexOf(attribute) > -1;
           let keyIsArray = Array.isArray(updateData[attribute]);
-          let isObjectWithKeys = typeof modelInstance[attribute] == 'object' && !keyIsArray && Object.keys(modelInstance[attribute]).length;
+          let isObjectWithKeys = modelInstance[attribute] !== null && typeof modelInstance[attribute] == 'object' && !keyIsArray && Object.keys(modelInstance[attribute]).length;
 
           let keyIsUpdatable = Object.prototype.hasOwnProperty.call(updateData, attribute) && attribute !== '_id' && !isProtectedKey && !isObjectWithKeys;
           let isNestedKey = Object.prototype.hasOwnProperty.call(updateData, attribute) && attribute !== '_id' && !isProtectedKey && isObjectWithKeys;


### PR DESCRIPTION
I was getting this error message when using mongoose-patch-update with node.js v7.10:

>  TypeError: updateData.hasOwnProperty is not a function
>     at findOne.select.exec.then (C:\x\node_modules\mongoose-patch-update\index.js:34:43)
>     at newTickHandler (C:\x\node_modules\mpromise\lib\promise.js:234:18)
>     at _combinedTickCallback (internal/process/next_tick.js:73:7)
>     at process._tickCallback (internal/process/next_tick.js:104:9)

There have been some changes in node.js v.6.x that is the cause of this error. It's discussed [here](https://github.com/nodejs/node/pull/6289).

Another problem I had was when trying to update a field in the model that was null before. It gave the following error:

>   TypeError: Cannot convert undefined or null to object
>        at Function.keys (<anonymous>)
>        at findOne.select.exec.then (C:\x\node_modules\mongoose-patch-update\index.js:32:103)
>        at newTickHandler (C:\x\node_modules\mpromise\lib\promise.js:234:18)
>        at _combinedTickCallback (internal/process/next_tick.js:73:7)
>        at process._tickCallback (internal/process/next_tick.js:104:9),
>   status: 400 }

typeof modelInstance[attribute] == 'object' will return true when the type is null, so I added an extra check for null.